### PR TITLE
Add chefignore file

### DIFF
--- a/.chefignore
+++ b/.chefignore
@@ -77,11 +77,6 @@ Berksfile.lock
 cookbooks/*
 tmp
 
-# Cookbooks #
-#############
-CONTRIBUTING
-CHANGELOG*
-
 # Vagrant #
 ###########
 .vagrant


### PR DESCRIPTION
As is mentioned in this page https://docs.chef.io/chef_repo.html#chefignore-files we must add this file to prevent useless insertions of files during the making of the tarball.
