### PR TITLE
Path is no longer use by Chef 12

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -20,9 +20,7 @@
 action :run do
   bamboo_config  = node['bamboo-agent']
   user           = bamboo_config['user']
-
-  server_url     = "#{bamboo_config['server']['protocol']}://#{bamboo_config['server']['address']}:#{bamboo_config['server']['port']}"
-
+  server_url     = bamboo_config['server']['url']
   home_directory = "#{bamboo_config['install_dir']}/agent#{new_resource.id}-home"
   script_path    = "#{home_directory}/bin/bamboo-agent.sh"
   service_name   = "bamboo-agent#{new_resource.id}"
@@ -40,7 +38,7 @@ action :run do
   end
 
   execute "install-agent#{new_resource.id}" do
-    path ['/bin', '/usr/bin', '/usr/local/bin']
+    environment 'PATH' => "/bin:/usr/bin:/usr/local/bin:#{ENV['PATH']}"
     user user['name']
     group user['group']
     command "java -Dbamboo.home=#{home_directory} -jar #{bamboo_config['installer_jar']} '#{server_url}/agentServer' install"

--- a/recipes/download.rb
+++ b/recipes/download.rb
@@ -49,7 +49,7 @@ end
 
 server_config = bamboo_config['server']
 remote_file 'bamboo-agent-installer' do
-  source "#{server_config['protocol']}://#{server_config['address']}:#{server_config['port']}/agentServer/agentInstaller"
+  source "#{server_config['url']}/agentServer/agentInstaller"
   path bamboo_config['installer_jar']
   mode '0644'
   owner user['name']

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -80,7 +80,6 @@ describe 'bamboo-agent::install' do
       )
 
       expect(subject).to run_execute('install-agent1').with(
-        path: ['/bin', '/usr/bin', '/usr/local/bin'],
         user: 'bamboo',
         group: 'bamboo',
         command: 'java -Dbamboo.home=/usr/local/bamboo/agent1-home -jar /usr/local/bamboo/bamboo-agent-installer.jar \'http://localhost:8085/agentServer\' install',


### PR DESCRIPTION
More, use server url attribute instead of reconstructing it.

Detailed error:
```
WARN: 'path' attribute of 'execute' is not used by any provider in Chef 11 and Chef 12. Use 'environment' attribute to configure 'PATH'. This attribute will be removed in Chef 13.
```