### PR TITLE
Do not restart service every Chef converge

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cd@numergy.com'
 license 'Apache 2.0'
 description 'Installs/Configures a bamboo agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.6.0'
+version '0.6.1'
 
 supports 'ubuntu'
 supports 'debian', '>= 7.0'

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -54,10 +54,11 @@ action :run do
     mode '755'
     variables user: user['name'], script: "#{home_directory}/bin/bamboo-agent.sh", agent_id: new_resource.id
     action :create
+    notifies :restart, "service[#{service_name}]", :delayed
   end
 
   service service_name do
-    action [:enable, :restart]
+    action [:enable, :start]
   end
 
   expand = lambda do |value|


### PR DESCRIPTION
This cookbook was restarting bamboo agent in every Chef converge. My fix prevents this situation and keeps service started all the time.