### PR TITLE
Init script

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,9 +7,8 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
-  - name: debian-7.6
-    driver_config:
-      box: chef/debian-7.6
+  - name: ubuntu-14.04
+  - name: debian-7.1
   - name: centos-6.4
 
 suites:

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -61,6 +61,7 @@ action :run do
 
   service service_name do
     action [:enable, :start]
+    supports restart: true, status: true
   end
 
   expand = lambda do |value|

--- a/templates/default/init-script.erb
+++ b/templates/default/init-script.erb
@@ -1,11 +1,21 @@
 #!/bin/bash
 # bamboo-agent<%= @agent_id.to_s.ljust(4) %> Init script for running bamboo agent
 #
-# chkconfig: 2345 98 02
+# chkconfig:       2345 98 02
 #
-# description: Starts and stops bamboo agent <%= @agent_id %>
-
-# This is just a delegator to the Bamboo agent script.
+# description:     Starts and stops bamboo agent <%= @agent_id %>
+#
+### BEGIN INIT INFO
+# Provides:          bamboo-agent<%= @agent_id.to_s.ljust(4) %>
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs $remote_fs $network
+# Should-Start:      $named
+# Should-Stop:       $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts and stops bamboo agent <%= @agent_id %>
+# Description:       This is just a delegator to the Bamboo agent script.
+### END INIT INFO
 
 if [[ "$EUID" != '0' ]]; then
   echo 'This script must be run as root!'


### PR DESCRIPTION
- Use boxes store on http://opscode-vm-bento.s3.amazonaws.com/ for kitchen.yml
- Service bamboo agent must supports restart and status to prevent errors when start action is used
- Update init script to include LSBInitScripts (https://wiki.debian.org/LSBInitScripts)