### PR TITLE
Add component recursive dir and manage home

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,16 @@ Attributes
   <tr>
     <td><tt>['bamboo-agent']['install_dir']</tt></td>
     <td>String</td>
-    <td>whether to install bamboo agents</td>
+    <td>Where to install bamboo agents</td>
     <td><tt>/usr/local/bamboo</tt></td>
   </tr>
+  <tr>
+    <td><tt>['bamboo-agent']['install_dir']['recursive']</tt></td>
+    <td>Boolean</td>
+    <td>Recursively create install_dir</td>
+    <td><tt>false</tt></td>
+  </tr>
+
   <tr>
     <td><tt>['bamboo-agent']['installer_jar']</tt></td>
     <td>String</td>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,7 @@ default['bamboo-agent']['server']['port'] = 8085
 default['bamboo-agent']['server']['url'] = "#{node['bamboo-agent']['server']['protocol']}://#{node['bamboo-agent']['server']['address']}:#{node['bamboo-agent']['server']['port']}"
 
 default['bamboo-agent']['install_dir'] = '/usr/local/bamboo'
+default['bamboo-agent']['install_dir']['recursive'] = false
 default['bamboo-agent']['installer_jar'] = "#{node['bamboo-agent']['install_dir']}/bamboo-agent-installer.jar"
 
 default['bamboo-agent']['user']['name'] = 'bamboo'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cd@numergy.com'
 license 'Apache 2.0'
 description 'Installs/Configures a bamboo agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.7.0'
+version '0.7.1'
 
 supports 'ubuntu'
 supports 'debian', '>= 7.0'

--- a/recipes/download.rb
+++ b/recipes/download.rb
@@ -31,7 +31,7 @@ ohai 'reload_passwd' do
 end
 
 user user['name'] do
-  supports manage_home: user['manage']
+  manage_home user['manage']
   home "/home/#{user['name']}"
   gid user['group']
   shell user['shell']
@@ -41,6 +41,7 @@ end
 
 directory 'install-dir' do
   path bamboo_config['install_dir']
+  recursive bamboo_config['install_dir']['recursive']
   owner user['name']
   group user['group']
   mode '0755'


### PR DESCRIPTION
Added attribute for ..['install_dir']['recursive'] to allow recursive directory creation, defaulted to false so that it doesn't change current functionality.
Changed user resource, manage_home to straight assignment as the supports is deprecated? 
